### PR TITLE
build: goreleaser release machinery + cut v0.1.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,28 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write  # required for keyless cosign signing via Sigstore OIDC
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
+        with:
+          go-version-file: go.mod
+          cache: true
+      - uses: sigstore/cosign-installer@ba7bc0a3fef59531c69a25acd34668d6d3fe6f22 # v4.1.0
+      - uses: goreleaser/goreleaser-action@ec59f474b9834571250b370d4735c50f8e2d1e29 # v7.0.0
+        with:
+          version: latest
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,43 @@
+version: 2
+before:
+  hooks:
+    - go mod tidy
+builds:
+  - env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+      - windows
+    goarch:
+      - amd64
+      - arm64
+    ldflags:
+      - -s -w -X github.com/scttfrdmn/ood-emr-adapter/cmd.version={{.Version}}
+archives:
+  - formats: [tar.gz]
+    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    format_overrides:
+      - goos: windows
+        formats: [zip]
+checksum:
+  name_template: "checksums.txt"
+signs:
+  - cmd: cosign
+    signature: "${artifact}.bundle"
+    args:
+      - sign-blob
+      - "--bundle=${signature}"
+      - "${artifact}"
+      - --yes
+    artifacts: checksum
+    output: true
+snapshot:
+  version_template: "{{ .Tag }}-next"
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - "^docs:"
+      - "^test:"
+      - "^chore:"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.0] - 2026-05-30
+
 ### Fixed
 - Bumped `github.com/scttfrdmn/substrate` 0.45.2 → 0.65.0 and regenerated go.sum. The recorded 0.45.2 checksum no longer matched the module the proxy serves (upstream re-tag), which broke `go test -tags=integration` with a go.sum SECURITY ERROR. Integration tests now build and pass.
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -9,7 +9,10 @@ var (
 	applicationID string
 )
 
+var version = "dev" // overridden at release time via -ldflags -X .../cmd.version
+
 var rootCmd = &cobra.Command{
+	Version: version,
 	Use:   "ood-emr-adapter",
 	Short: "OOD compute adapter for Amazon EMR Serverless",
 	Long:  "Translates Open OnDemand job submissions to Amazon EMR Serverless API calls.",


### PR DESCRIPTION
Adds tag-triggered goreleaser release machinery (cosign-signed multi-arch binaries — the artifacts the Marketplace/CloudFormation path fetches) and cuts the `[0.1.0]` CHANGELOG section. Modeled on aws-role-exec, minus homebrew/scoop (server-side adapter binaries, not user-installed CLIs). Adds a cobra `Version` wired via `-ldflags -X .../cmd.version`. Verified locally: `go build/vet/test` green, `goreleaser check` valid, `--version` reports correctly.